### PR TITLE
Spike profile-driven workspace orchestration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ bin/
 
 # wt-forge config (user-specific)
 .wt-forge.toml
+
+# Runtime state for profile workspaces (the manifest is committed).
+.wtf/state/

--- a/.wtf/workspace.yaml
+++ b/.wtf/workspace.yaml
@@ -1,0 +1,14 @@
+version: 1
+
+profiles:
+  wtf:
+    services: [wtf]
+
+services:
+  wtf:
+    # This dogfoods a profile whose only component is this repository.
+    dir: .
+    source: worktree
+    ports:
+      http: {from: 8080, to: 8099}
+    up: task build

--- a/README.md
+++ b/README.md
@@ -72,6 +72,25 @@ wtf new feature/auth --no-env       # skip env file handling
 wtf new feature/auth --no-install   # skip package install
 ```
 
+## Profile Workspaces (spike)
+
+This branch adds the configuration and planning foundation for multi-repo local
+environments. A workspace is a parent directory containing `.wtf/workspace.yaml`
+and one or more service directories. It provides native-process `up`/`down` orchestration for the declared
+profile:
+
+```bash
+# Run from the workspace root or any descendant service directory.
+wtf plan fullstack feature/auth
+wtf up fullstack feature/auth
+wtf down feature/auth
+
+# While developing this branch without installing the binary:
+go run ./cmd/wtf up fullstack feature/auth
+```
+
+See [docs/plan.md](docs/plan.md) for the manifest and setup steps.
+
 ## Shell Integration
 
 `wtf sw` prints the worktree path to stdout (a subprocess can't `cd` your shell). The shell wrapper intercepts `wtf sw` to `cd` automatically. Tab completions are also included — one line handles everything.
@@ -132,6 +151,12 @@ Worktrees are created as sibling directories to the main repo. Slashes in branch
 | `wtf repos`      | List all registered repos                               |
 | `wtf unregister` | Remove a repo from the registry                         |
 | `wtf watch`      | Watch PRs for changes and send notifications (`-g`, `-i`) |
+
+### Workspace Profiles (spike)
+
+| Command    | Description                                              |
+|------------|----------------------------------------------------------|
+| `wtf plan` | Validate and render a profile instance without side effects |
 
 ### Tooling
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,0 +1,117 @@
+# wtf plan (spike)
+
+Render and validate a profile-driven local environment without changing the
+filesystem.
+
+```bash
+wtf plan <profile> <instance>
+```
+
+> **Spike status:** `wtf plan` is read-only. `wtf up` materializes the
+> declared worktrees, env files, port leases, and commands; `wtf down` stops
+> recorded processes and releases port leases. Worktrees are intentionally
+> retained so uncommitted work is never deleted.
+
+## Setup and run
+
+1. Create a workspace directory and put participating repos or directories in
+   it. A service path is relative to that directory (`.` is valid for the
+   workspace root) and cannot escape it with `..`.
+2. Create `<workspace>/.wtf/workspace.yaml`:
+
+```yaml
+# <workspace>/.wtf/workspace.yaml
+version: 1
+
+profiles:
+  fullstack:
+    services: [web, api]
+
+services:
+  web:
+    dir: web
+    env:
+      path: .env
+      mode: copy
+      set:
+        PORT: "${port.web_http}"
+        NEXT_PUBLIC_API_URL: "http://127.0.0.1:${port.api_http}/"
+    ports:
+      web_http: {from: 3000, to: 3099}
+    up: pnpm exec next dev --port $PORT
+
+  api:
+    dir: api
+    source: worktree # default; use directory for an existing, shared directory
+    env:
+      path: app/.env
+      mode: copy
+      set:
+        PORT: "${port.api_http}"
+    ports:
+      api_http: {from: 8000, to: 8099}
+    up: uv run manage.py runserver 0.0.0.0:$PORT
+```
+
+3. Run the plan or start the environment from the workspace root **or any
+   descendant directory**. WTF searches parent directories for
+   `.wtf/workspace.yaml`.
+
+```bash
+$ cd <workspace>/api
+$ wtf plan fullstack feature/auth
+Profile fullstack · instance feature/auth
+workspace: <workspace>
+
+web
+  dir: <workspace>/web
+  source: worktree
+  worktree: feature/auth
+  port: http (3000-3099)
+
+api
+  dir: <workspace>/api
+  source: worktree
+  worktree: feature/auth
+  env: app/.env (copy)
+  port: api_http (8000-8099)
+  up: uv run python manage.py runserver 0.0.0.0:$PORT
+```
+
+## Manifest reference
+
+- `version`: must be `1`.
+- `profiles.<name>.services`: ordered list of service names to include.
+- `services.<name>.dir`: required path relative to the workspace root; `.`
+  selects the root itself.
+- `services.<name>.source`: `worktree` (the default) or `directory`. The plan
+  labels worktree services with the requested instance; directory services are
+  intentionally shared.
+- `services.<name>.env`: optional `{path, mode, set}`. `path` is the dotenv
+  path relative to the service root; `mode` is `copy` or `symlink`. `set`
+  safely upserts values only into copied files and supports `${instance}` and
+  `${port.<name>}` interpolation.
+- `services.<name>.ports.<name>`: an optional `{from, to}` inclusive range.
+  `up` leases a free value from the range for the instance.
+- `services.<name>.up`: an opaque application command. WTF does not interpret
+  Django, Node, Docker, or any other framework syntax.
+
+Start and stop the instance:
+
+```bash
+wtf up fullstack feature/auth
+wtf down feature/auth
+```
+
+Use `--json` for scripts and agents:
+
+```bash
+wtf plan fullstack feature/auth --json
+wtf up fullstack feature/auth --json
+wtf ps
+wtf ps --global
+```
+
+Runtime state and command logs are stored under `.wtf/state/`, which is ignored
+by Git. `down` preserves created worktrees; use the existing `wtf rm` workflow
+when you have finished with a branch.

--- a/internal/cli/plan.go
+++ b/internal/cli/plan.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/AndrewPBerg/wtf/internal/workspace"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(planCmd)
+}
+
+var planCmd = &cobra.Command{
+	Use:   "plan <profile> <instance>",
+	Short: "Show the environment a profile would materialize",
+	Long: `Resolve a profile from .wtf/workspace.yaml without creating worktrees,
+copying environment files, allocating ports, or starting processes.
+
+This is the first, deliberately side-effect-free step of WTF's profile-driven
+workspace spike.`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runPlan(cmd, args[0], args[1])
+	},
+}
+
+func runPlan(cmd *cobra.Command, profile, instance string) error {
+	dir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getting current directory: %w", err)
+	}
+	config, root, err := workspace.Load(dir)
+	if err != nil {
+		return err
+	}
+	plan, err := workspace.BuildPlan(config, root, profile, instance)
+	if err != nil {
+		return err
+	}
+
+	if jsonOutput {
+		return writeJSON(cmd.OutOrStdout(), plan)
+	}
+
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintf(out, "Profile %s · instance %s\n", cyan(plan.Profile), cyan(plan.Instance))
+	_, _ = fmt.Fprintf(out, "workspace: %s\n", plan.Workspace)
+	for _, service := range plan.Services {
+		_, _ = fmt.Fprintf(out, "\n%s\n  dir: %s\n  source: %s\n", bold(service.Name), service.Dir, service.Source)
+		if service.WorktreeFor != "" {
+			_, _ = fmt.Fprintf(out, "  worktree: %s\n", service.WorktreeFor)
+		}
+		if env := service.Env; env != nil {
+			_, _ = fmt.Fprintf(out, "  env: %s (%s)\n", env.Path, env.Mode)
+		}
+		portNames := make([]string, 0, len(service.Ports))
+		for name := range service.Ports {
+			portNames = append(portNames, name)
+		}
+		sort.Strings(portNames)
+		for _, name := range portNames {
+			port := service.Ports[name]
+			_, _ = fmt.Fprintf(out, "  port: %s (%d-%d)\n", name, port.From, port.To)
+		}
+		if service.Up != "" {
+			_, _ = fmt.Fprintf(out, "  up: %s\n", strings.TrimSpace(service.Up))
+		}
+	}
+	return nil
+}

--- a/internal/cli/plan_test.go
+++ b/internal/cli/plan_test.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunPlan(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(root, ".wtf"), 0o755))
+	config := `version: 1
+profiles:
+  fullstack:
+    services: [api]
+services:
+  api:
+    dir: api
+    env: {path: .env, mode: copy}
+    ports:
+      http: {from: 8000, to: 8099}
+    up: uv run python manage.py runserver 0.0.0.0:$PORT
+`
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".wtf", "workspace.yaml"), []byte(config), 0o600))
+	require.NoError(t, os.Mkdir(filepath.Join(root, "api"), 0o755))
+	t.Chdir(filepath.Join(root, "api"))
+
+	out := new(bytes.Buffer)
+	cmd := planCmd
+	cmd.SetOut(out)
+	cmd.SetErr(new(bytes.Buffer))
+
+	require.NoError(t, runPlan(cmd, "fullstack", "feature/auth"))
+	assert.Contains(t, out.String(), "instance feature/auth")
+	assert.Contains(t, out.String(), "api")
+	assert.Contains(t, out.String(), "8000-8099")
+	assert.Contains(t, out.String(), "copy")
+}
+
+func TestRunPlanJSON(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(root, ".wtf"), 0o755))
+	config := "version: 1\nprofiles: {dev: {services: [app]}}\nservices: {app: {dir: app}}\n"
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".wtf", "workspace.yaml"), []byte(config), 0o600))
+	t.Chdir(root)
+
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = false })
+	out := new(bytes.Buffer)
+	cmd := planCmd
+	cmd.SetOut(out)
+
+	require.NoError(t, runPlan(cmd, "dev", "one"))
+	assert.Contains(t, out.String(), `"profile": "dev"`)
+	assert.Contains(t, out.String(), `"instance": "one"`)
+}

--- a/internal/cli/ps.go
+++ b/internal/cli/ps.go
@@ -1,0 +1,75 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/AndrewPBerg/wtf/internal/workspace"
+	"github.com/spf13/cobra"
+)
+
+var psGlobal bool
+
+func init() {
+	rootCmd.AddCommand(psCmd)
+	psCmd.Flags().BoolVarP(&psGlobal, "global", "g", false, "List instances from registered workspaces")
+}
+
+var psCmd = &cobra.Command{Use: "ps", Short: "List running profile instances in this workspace", Args: cobra.NoArgs, RunE: func(cmd *cobra.Command, _ []string) error { return runPS(cmd) }}
+
+func runPS(cmd *cobra.Command) error {
+	dir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getting current directory: %w", err)
+	}
+	var roots []string
+	if psGlobal {
+		roots, err = workspace.Registered()
+		if err != nil {
+			return fmt.Errorf("listing registered workspaces: %w", err)
+		}
+	} else {
+		_, root, loadErr := workspace.Load(dir)
+		if loadErr != nil {
+			return loadErr
+		}
+		if err := workspace.Register(root); err != nil {
+			return fmt.Errorf("registering workspace: %w", err)
+		}
+		roots = []string{root}
+	}
+	states := []workspace.RuntimeState{}
+	for _, workspaceRoot := range roots {
+		listed, listErr := workspace.List(workspaceRoot)
+		if listErr != nil {
+			return fmt.Errorf("listing instances in %s: %w", workspaceRoot, listErr)
+		}
+		states = append(states, listed...)
+	}
+	if err != nil {
+		return fmt.Errorf("listing instances: %w", err)
+	}
+	if jsonOutput {
+		return writeJSON(cmd.OutOrStdout(), states)
+	}
+	if len(states) == 0 {
+		_, err := fmt.Fprintln(cmd.OutOrStdout(), "No profile instances")
+		return err
+	}
+	for _, state := range states {
+		ports := []int{}
+		for _, service := range state.Services {
+			for _, port := range service.Ports {
+				ports = append(ports, port)
+			}
+		}
+		sort.Ints(ports)
+		status := "stopped"
+		if workspace.IsRunning(state) {
+			status = "running"
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s  %s  ports %v  %s\n", state.Instance, state.Profile, ports, status)
+	}
+	return nil
+}

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/AndrewPBerg/wtf/internal/workspace"
+	"github.com/spf13/cobra"
+)
+
+func init() { rootCmd.AddCommand(upCmd, downCmd) }
+
+var upCmd = &cobra.Command{Use: "up <profile> <instance>", Short: "Materialize and start a profile environment", Args: cobra.ExactArgs(2), RunE: func(cmd *cobra.Command, args []string) error { return runUp(cmd, args[0], args[1]) }}
+var downCmd = &cobra.Command{Use: "down <instance>", Short: "Stop a profile environment and release its resources", Args: cobra.ExactArgs(1), RunE: func(cmd *cobra.Command, args []string) error { return runDown(cmd, args[0]) }}
+
+func runUp(cmd *cobra.Command, profile, instance string) error {
+	dir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getting current directory: %w", err)
+	}
+	config, root, err := workspace.Load(dir)
+	if err != nil {
+		return err
+	}
+	state, err := workspace.Up(config, root, profile, instance)
+	if err != nil {
+		return err
+	}
+	if jsonOutput {
+		return writeJSON(cmd.OutOrStdout(), state)
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "Started %s (%s)\n", cyan(instance), cyan(profile))
+	return err
+}
+func runDown(cmd *cobra.Command, instance string) error {
+	dir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getting current directory: %w", err)
+	}
+	_, root, err := workspace.Load(dir)
+	if err != nil {
+		return err
+	}
+	if err := workspace.Down(root, instance); err != nil {
+		return err
+	}
+	if jsonOutput {
+		return writeJSON(cmd.OutOrStdout(), map[string]string{"instance": instance, "status": "stopped"})
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "Stopped %s\n", cyan(instance))
+	return err
+}

--- a/internal/workspace/alive_unix.go
+++ b/internal/workspace/alive_unix.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package workspace
+
+import "syscall"
+
+func processAlive(pid int) bool { return pid > 0 && syscall.Kill(pid, 0) == nil }

--- a/internal/workspace/alive_windows.go
+++ b/internal/workspace/alive_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package workspace
+
+import "os"
+
+func processAlive(pid int) bool {
+	p, err := os.FindProcess(pid)
+	return err == nil && p != nil
+}

--- a/internal/workspace/command.go
+++ b/internal/workspace/command.go
@@ -1,0 +1,21 @@
+package workspace
+
+import (
+	"os"
+	"os/exec"
+)
+
+// setupExecutor keeps lifecycle progress off stdout so --json remains valid.
+type setupExecutor struct{}
+
+func (setupExecutor) RunShell(dir, command string) error {
+	cmd := exec.Command("sh", "-c", command)
+	cmd.Dir = dir
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func (setupExecutor) RunInteractive(dir, command string) error {
+	return setupExecutor{}.RunShell(dir, command)
+}

--- a/internal/workspace/config.go
+++ b/internal/workspace/config.go
@@ -1,0 +1,206 @@
+// Package workspace defines profile-driven local development environments.
+package workspace
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const configDirName = ".wtf"
+const configFileName = "workspace.yaml"
+
+// Config is the committed description of a local development workspace.
+type Config struct {
+	Version  int                `yaml:"version" json:"version"`
+	Profiles map[string]Profile `yaml:"profiles" json:"profiles"`
+	Services map[string]Service `yaml:"services" json:"services"`
+}
+
+// Profile selects the services that form an environment.
+type Profile struct {
+	Services []string `yaml:"services" json:"services"`
+}
+
+// Service describes one repository or directory participating in a profile.
+// WTF deliberately treats Up as an opaque command; framework knowledge remains
+// in the workspace configuration.
+type Service struct {
+	Dir     string            `yaml:"dir" json:"dir"`
+	Source  string            `yaml:"source" json:"source"` // worktree (default) or directory
+	Env     *Environment      `yaml:"env" json:"env"`
+	Ports   map[string]Port   `yaml:"ports" json:"ports"`
+	Up      string            `yaml:"up" json:"up"`
+	EnvVars map[string]string `yaml:"environment" json:"environment"`
+}
+
+// Environment materializes and optionally masks one dotenv file.
+type Environment struct {
+	Path string            `yaml:"path" json:"path"`
+	Mode string            `yaml:"mode" json:"mode"` // copy or symlink
+	Set  map[string]string `yaml:"set" json:"set"`
+}
+
+// Port declares a named service port and its allocation range.
+type Port struct {
+	From int `yaml:"from" json:"from"`
+	To   int `yaml:"to" json:"to"`
+}
+
+// Load searches dir and its parents for .wtf/workspace.yaml, then decodes and
+// validates it. The returned directory is the workspace root (the parent of
+// .wtf), not the directory in which the command was invoked.
+func Load(dir string) (*Config, string, error) {
+	root, path, err := findConfig(dir)
+	if err != nil {
+		return nil, "", err
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, "", fmt.Errorf("opening workspace config: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	config, err := decode(file)
+	if err != nil {
+		return nil, "", err
+	}
+	if err := config.Validate(); err != nil {
+		return nil, "", err
+	}
+	return config, root, nil
+}
+
+func findConfig(dir string) (string, string, error) {
+	current, err := filepath.Abs(dir)
+	if err != nil {
+		return "", "", fmt.Errorf("resolving workspace directory: %w", err)
+	}
+
+	for {
+		path := filepath.Join(current, configDirName, configFileName)
+		info, statErr := os.Stat(path)
+		switch {
+		case statErr == nil && info.IsDir():
+			return "", "", fmt.Errorf("workspace config %s is a directory", path)
+		case statErr == nil:
+			return current, path, nil
+		case !os.IsNotExist(statErr):
+			return "", "", fmt.Errorf("checking workspace config %s: %w", path, statErr)
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", "", fmt.Errorf("no %s/%s found from %s", configDirName, configFileName, dir)
+		}
+		current = parent
+	}
+}
+
+func decode(r io.Reader) (*Config, error) {
+	var config Config
+	decoder := yaml.NewDecoder(r)
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&config); err != nil {
+		return nil, fmt.Errorf("parsing workspace config: %w", err)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("workspace config must contain a single YAML document")
+		}
+		return nil, fmt.Errorf("parsing workspace config: %w", err)
+	}
+	return &config, nil
+}
+
+// Validate verifies the schema and cross-references without inspecting or
+// modifying service directories.
+func (c *Config) Validate() error {
+	if c.Version != 1 {
+		return fmt.Errorf("workspace config version must be 1")
+	}
+	if len(c.Profiles) == 0 {
+		return fmt.Errorf("workspace config must declare at least one profile")
+	}
+	if len(c.Services) == 0 {
+		return fmt.Errorf("workspace config must declare at least one service")
+	}
+
+	for name, profile := range c.Profiles {
+		if name == "" {
+			return fmt.Errorf("profile name cannot be empty")
+		}
+		if len(profile.Services) == 0 {
+			return fmt.Errorf("profile %q must declare at least one service", name)
+		}
+		seen := make(map[string]bool, len(profile.Services))
+		for _, service := range profile.Services {
+			if seen[service] {
+				return fmt.Errorf("profile %q declares service %q more than once", name, service)
+			}
+			seen[service] = true
+			if _, ok := c.Services[service]; !ok {
+				return fmt.Errorf("profile %q references unknown service %q", name, service)
+			}
+		}
+	}
+
+	for name, service := range c.Services {
+		if name == "" {
+			return fmt.Errorf("service name cannot be empty")
+		}
+		if service.Dir == "" {
+			return fmt.Errorf("service %q must declare dir", name)
+		}
+		if !isWorkspaceDir(service.Dir) {
+			return fmt.Errorf("service %q dir must be relative to the workspace root", name)
+		}
+		if service.Source != "" && service.Source != "worktree" && service.Source != "directory" {
+			return fmt.Errorf("service %q has unsupported source %q", name, service.Source)
+		}
+		if service.Source == "directory" && service.Env != nil {
+			return fmt.Errorf("service %q cannot materialize env files for directory source", name)
+		}
+		if env := service.Env; env != nil {
+			if !isWorkspaceRelative(env.Path) {
+				return fmt.Errorf("service %q env path must be relative", name)
+			}
+			if env.Mode != "copy" && env.Mode != "symlink" {
+				return fmt.Errorf("service %q env has unsupported mode %q", name, env.Mode)
+			}
+			if env.Mode == "symlink" && len(env.Set) > 0 {
+				return fmt.Errorf("service %q cannot set values in a symlinked env file", name)
+			}
+		}
+		for portName, port := range service.Ports {
+			if portName == "" || port.From < 1 || port.To < port.From || port.To > 65535 {
+				return fmt.Errorf("service %q port %q has invalid range", name, portName)
+			}
+		}
+	}
+	return nil
+}
+
+func isWorkspaceDir(path string) bool {
+	return isSafeRelative(path, true)
+}
+
+func isWorkspaceRelative(path string) bool {
+	return isSafeRelative(path, false)
+}
+
+func isSafeRelative(path string, allowCurrentDir bool) bool {
+	if path == "" || filepath.IsAbs(path) {
+		return false
+	}
+	clean := filepath.Clean(path)
+	if allowCurrentDir && clean == "." {
+		return true
+	}
+	return clean != "." && clean != ".." && !strings.HasPrefix(clean, ".."+string(filepath.Separator))
+}

--- a/internal/workspace/config_test.go
+++ b/internal/workspace/config_test.go
@@ -1,0 +1,125 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const validConfig = `version: 1
+profiles:
+  fullstack:
+    services: [web, api]
+services:
+  web:
+    dir: web
+    ports:
+      http: {from: 3000, to: 3099}
+    up: pnpm dev -- --port $PORT
+  api:
+    dir: api
+    env: {path: .env, mode: copy}
+    ports:
+      http: {from: 8000, to: 8099}
+    up: uv run python manage.py runserver 0.0.0.0:$PORT
+`
+
+func TestLoadFindsParentWorkspaceConfig(t *testing.T) {
+	root := t.TempDir()
+	configDir := filepath.Join(root, ".wtf")
+	require.NoError(t, os.Mkdir(configDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "workspace.yaml"), []byte(validConfig), 0o600))
+
+	child := filepath.Join(root, "api", "nested")
+	require.NoError(t, os.MkdirAll(child, 0o755))
+	config, gotRoot, err := Load(child)
+
+	require.NoError(t, err)
+	assert.Equal(t, root, gotRoot)
+	assert.Len(t, config.Profiles, 1)
+	assert.Equal(t, "api", config.Services["api"].Dir)
+}
+
+func TestLoadRejectsUnknownFields(t *testing.T) {
+	root := t.TempDir()
+	configDir := filepath.Join(root, ".wtf")
+	require.NoError(t, os.Mkdir(configDir, 0o755))
+	contents := "version: 1\nprofiles: {app: {services: [app]}}\nservices: {app: {dir: app, typo: no}}\n"
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "workspace.yaml"), []byte(contents), 0o600))
+
+	_, _, err := Load(root)
+
+	assert.ErrorContains(t, err, "field typo not found")
+}
+
+func TestLoadRejectsMultipleDocuments(t *testing.T) {
+	root := t.TempDir()
+	configDir := filepath.Join(root, ".wtf")
+	require.NoError(t, os.Mkdir(configDir, 0o755))
+	contents := validConfig + "---\nversion: 1\n"
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "workspace.yaml"), []byte(contents), 0o600))
+
+	_, _, err := Load(root)
+
+	assert.ErrorContains(t, err, "single YAML document")
+}
+
+func TestLoadRejectsConfigDirectory(t *testing.T) {
+	root := t.TempDir()
+	configPath := filepath.Join(root, ".wtf", "workspace.yaml")
+	require.NoError(t, os.MkdirAll(configPath, 0o755))
+
+	_, _, err := Load(root)
+
+	assert.ErrorContains(t, err, "is a directory")
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  Config
+		wantErr string
+	}{
+		{
+			name:    "unknown profile service",
+			config:  Config{Version: 1, Profiles: map[string]Profile{"dev": {Services: []string{"missing"}}}, Services: map[string]Service{"other": {Dir: "other"}}},
+			wantErr: `references unknown service "missing"`,
+		},
+		{
+			name:    "absolute service directory",
+			config:  Config{Version: 1, Profiles: map[string]Profile{"dev": {Services: []string{"app"}}}, Services: map[string]Service{"app": {Dir: "/app"}}},
+			wantErr: "must be relative",
+		},
+		{
+			name:    "service directory cannot escape workspace",
+			config:  Config{Version: 1, Profiles: map[string]Profile{"dev": {Services: []string{"app"}}}, Services: map[string]Service{"app": {Dir: "../app"}}},
+			wantErr: "must be relative",
+		},
+		{
+			name:   "workspace root is a valid service directory",
+			config: Config{Version: 1, Profiles: map[string]Profile{"dev": {Services: []string{"app"}}}, Services: map[string]Service{"app": {Dir: "."}}},
+		},
+		{
+			name:    "directory sources cannot materialize env files",
+			config:  Config{Version: 1, Profiles: map[string]Profile{"dev": {Services: []string{"app"}}}, Services: map[string]Service{"app": {Dir: "app", Source: "directory", Env: &Environment{Path: ".env", Mode: "symlink"}}}},
+			wantErr: "cannot materialize env files",
+		},
+		{
+			name:   "worktree symlink is supported",
+			config: Config{Version: 1, Profiles: map[string]Profile{"dev": {Services: []string{"app"}}}, Services: map[string]Service{"app": {Dir: "app", Source: "worktree", Env: &Environment{Path: ".env", Mode: "symlink"}}}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			assert.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}

--- a/internal/workspace/list.go
+++ b/internal/workspace/list.go
@@ -1,0 +1,88 @@
+package workspace
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// Register records a workspace root for global instance discovery.
+func Register(root string) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(home, ".wtf", "workspaces.json")
+	data, err := os.ReadFile(path)
+	roots := []string{}
+	if err == nil {
+		if err := json.Unmarshal(data, &roots); err != nil {
+			return err
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	for _, existing := range roots {
+		if existing == root {
+			return nil
+		}
+	}
+	roots = append(roots, root)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	out, err := json.MarshalIndent(roots, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, out, 0o600)
+}
+
+// Registered returns workspace roots previously seen by WTF.
+func Registered() ([]string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".wtf", "workspaces.json"))
+	if os.IsNotExist(err) {
+		return []string{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var roots []string
+	if err := json.Unmarshal(data, &roots); err != nil {
+		return nil, err
+	}
+	return roots, nil
+}
+
+// List returns every persisted instance for a workspace.
+func List(root string) ([]RuntimeState, error) {
+	entries, err := os.ReadDir(filepath.Join(root, ".wtf", "state", "instances"))
+	if os.IsNotExist(err) {
+		return []RuntimeState{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	states := make([]RuntimeState, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(root, ".wtf", "state", "instances", entry.Name()))
+		if err != nil {
+			return nil, err
+		}
+		var state RuntimeState
+		if err := json.Unmarshal(data, &state); err != nil {
+			return nil, err
+		}
+		states = append(states, state)
+	}
+	sort.Slice(states, func(i, j int) bool { return states[i].Instance < states[j].Instance })
+	return states, nil
+}

--- a/internal/workspace/lock.go
+++ b/internal/workspace/lock.go
@@ -1,0 +1,35 @@
+package workspace
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const lockTimeout = 10 * time.Second
+
+// withLock serializes lifecycle operations across WTF processes for one
+// workspace. A directory is created atomically on every supported platform.
+func withLock(root string, fn func() error) error {
+	path := filepath.Join(root, ".wtf", "state", "lock")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("creating workspace lock directory: %w", err)
+	}
+	deadline := time.Now().Add(lockTimeout)
+	for {
+		err := os.Mkdir(path, 0o700)
+		if err == nil {
+			defer func() { _ = os.Remove(path) }()
+			return fn()
+		}
+		if !errors.Is(err, os.ErrExist) {
+			return fmt.Errorf("acquiring workspace lock: %w", err)
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("workspace is busy: timed out waiting for %s", path)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+}

--- a/internal/workspace/lock_test.go
+++ b/internal/workspace/lock_test.go
@@ -1,0 +1,38 @@
+package workspace
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithLockSerializesConcurrentCallers(t *testing.T) {
+	root := t.TempDir()
+	var running, maxRunning int
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			require.NoError(t, withLock(root, func() error {
+				mu.Lock()
+				running++
+				if running > maxRunning {
+					maxRunning = running
+				}
+				mu.Unlock()
+				time.Sleep(50 * time.Millisecond)
+				mu.Lock()
+				running--
+				mu.Unlock()
+				return nil
+			}))
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, 1, maxRunning)
+}

--- a/internal/workspace/plan.go
+++ b/internal/workspace/plan.go
@@ -1,0 +1,69 @@
+package workspace
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+// Plan is a side-effect-free rendering of an environment instance. Execution,
+// resource leasing, and process management intentionally remain separate from
+// configuration parsing during this spike.
+type Plan struct {
+	Workspace string        `json:"workspace"`
+	Profile   string        `json:"profile"`
+	Instance  string        `json:"instance"`
+	Services  []PlanService `json:"services"`
+}
+
+// PlanService is one configured service resolved against a workspace root.
+type PlanService struct {
+	Name        string            `json:"name"`
+	Dir         string            `json:"dir"`
+	Source      string            `json:"source"`
+	WorktreeFor string            `json:"worktree_for,omitempty"`
+	Env         *Environment      `json:"env,omitempty"`
+	Ports       map[string]Port   `json:"ports,omitempty"`
+	Environment map[string]string `json:"environment,omitempty"`
+	Up          string            `json:"up,omitempty"`
+}
+
+// BuildPlan resolves one named profile for an environment instance. An
+// instance is normally a branch name, but WTF does not impose that meaning on
+// a profile: it is only a stable namespace for subsequent execution.
+func BuildPlan(config *Config, workspaceDir, profileName, instance string) (*Plan, error) {
+	if instance == "" {
+		return nil, fmt.Errorf("instance cannot be empty")
+	}
+	profile, ok := config.Profiles[profileName]
+	if !ok {
+		return nil, fmt.Errorf("profile %q not found", profileName)
+	}
+
+	plan := &Plan{
+		Workspace: workspaceDir,
+		Profile:   profileName,
+		Instance:  instance,
+		Services:  make([]PlanService, 0, len(profile.Services)),
+	}
+	for _, name := range profile.Services {
+		service := config.Services[name]
+		source := service.Source
+		if source == "" {
+			source = "worktree"
+		}
+		planned := PlanService{
+			Name:        name,
+			Dir:         filepath.Clean(filepath.Join(workspaceDir, service.Dir)),
+			Source:      source,
+			Env:         service.Env,
+			Ports:       service.Ports,
+			Environment: service.EnvVars,
+			Up:          service.Up,
+		}
+		if source == "worktree" {
+			planned.WorktreeFor = instance
+		}
+		plan.Services = append(plan.Services, planned)
+	}
+	return plan, nil
+}

--- a/internal/workspace/plan_test.go
+++ b/internal/workspace/plan_test.go
@@ -1,0 +1,45 @@
+package workspace
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildPlan(t *testing.T) {
+	config := &Config{
+		Version: 1,
+		Profiles: map[string]Profile{
+			"fullstack": {Services: []string{"web", "api"}},
+		},
+		Services: map[string]Service{
+			"web": {Dir: "web", Ports: map[string]Port{"http": {From: 3000, To: 3099}}},
+			"api": {Dir: "api", Source: "directory", Up: "uv run python manage.py runserver 0.0.0.0:$PORT"},
+		},
+	}
+
+	plan, err := BuildPlan(config, "/code/acme", "fullstack", "feature/auth")
+
+	require.NoError(t, err)
+	assert.Equal(t, "/code/acme", plan.Workspace)
+	assert.Equal(t, "feature/auth", plan.Instance)
+	require.Len(t, plan.Services, 2)
+	assert.Equal(t, filepath.Join("/code/acme", "web"), plan.Services[0].Dir)
+	assert.Equal(t, "feature/auth", plan.Services[0].WorktreeFor)
+	assert.Equal(t, 3000, plan.Services[0].Ports["http"].From)
+	assert.Equal(t, "api", plan.Services[1].Name)
+	assert.Equal(t, "directory", plan.Services[1].Source)
+	assert.Empty(t, plan.Services[1].WorktreeFor)
+}
+
+func TestBuildPlanErrors(t *testing.T) {
+	config := &Config{Profiles: map[string]Profile{"dev": {Services: []string{}}}}
+
+	_, err := BuildPlan(config, "/workspace", "missing", "feature/auth")
+	assert.ErrorContains(t, err, `profile "missing" not found`)
+
+	_, err = BuildPlan(config, "/workspace", "dev", "")
+	assert.ErrorContains(t, err, "instance cannot be empty")
+}

--- a/internal/workspace/process_unix.go
+++ b/internal/workspace/process_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package workspace
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func isolateProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+func stopProcess(pid int) error {
+	return syscall.Kill(-pid, syscall.SIGTERM)
+}

--- a/internal/workspace/process_windows.go
+++ b/internal/workspace/process_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package workspace
+
+import (
+	"os"
+	"os/exec"
+)
+
+func isolateProcess(_ *exec.Cmd) {}
+
+func stopProcess(pid int) error {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return process.Kill()
+}

--- a/internal/workspace/runtime.go
+++ b/internal/workspace/runtime.go
@@ -1,0 +1,324 @@
+package workspace
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	gitpkg "github.com/AndrewPBerg/wtf/internal/git"
+	"github.com/AndrewPBerg/wtf/internal/setup"
+)
+
+// RuntimeState is the persisted lifecycle state for one environment instance.
+type RuntimeState struct {
+	Profile  string           `json:"profile"`
+	Instance string           `json:"instance"`
+	Services []RunningService `json:"services"`
+}
+
+// RunningService records one materialized service and its assigned resources.
+type RunningService struct {
+	Name     string         `json:"name"`
+	Dir      string         `json:"dir"`
+	Worktree string         `json:"worktree,omitempty"`
+	Ports    map[string]int `json:"ports,omitempty"`
+	PID      int            `json:"pid,omitempty"`
+	Log      string         `json:"log,omitempty"`
+}
+
+// Up materializes the worktree and environment-file portion of a plan, leases
+// configured ports, and starts each declared command. State is persisted below
+// .wtf/state so Down can stop the same environment instance later.
+func Up(config *Config, root, profile, instance string) (*RuntimeState, error) {
+	var state *RuntimeState
+	err := withLock(root, func() error {
+		var err error
+		state, err = up(config, root, profile, instance)
+		return err
+	})
+	return state, err
+}
+
+func up(config *Config, root, profile, instance string) (*RuntimeState, error) {
+	plan, err := BuildPlan(config, root, profile, instance)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := loadState(root, instance); err == nil {
+		return nil, fmt.Errorf("instance %q is already up", instance)
+	} else if !os.IsNotExist(err) {
+		return nil, err
+	}
+	resources, err := loadResources(root)
+	if err != nil {
+		return nil, err
+	}
+	state := &RuntimeState{Profile: profile, Instance: instance}
+	completed := false
+	defer func() {
+		if !completed {
+			for _, service := range state.Services {
+				if service.PID > 0 {
+					_ = stopProcess(service.PID)
+				}
+			}
+		}
+	}()
+	wm := gitpkg.NewWorktreeManager(&gitpkg.RealExecutor{})
+	envHandler := setup.NewEnvFileHandler()
+	for _, service := range plan.Services {
+		target := service.Dir
+		running := RunningService{Name: service.Name, Ports: map[string]int{}}
+		if service.Source == "worktree" {
+			wt, findErr := wm.Find(service.Dir, instance)
+			if findErr == nil {
+				target = wt.Path
+			} else {
+				main, mainErr := wm.MainWorktree(service.Dir)
+				if mainErr != nil {
+					return nil, fmt.Errorf("finding base branch for %s: %w", service.Name, mainErr)
+				}
+				if main.Branch == "" {
+					return nil, fmt.Errorf("finding base branch for %s: main worktree is detached", service.Name)
+				}
+				created, addErr := wm.Add(service.Dir, instance, main.Branch)
+				if addErr != nil {
+					return nil, fmt.Errorf("creating worktree for %s: %w", service.Name, addErr)
+				}
+				target = created
+			}
+			running.Worktree = target
+		}
+		setupRunner := setup.NewRunner()
+		setupRunner.CmdExec = setupExecutor{}
+		if err := setupRunner.RunSetup(service.Dir, target, setup.Options{SkipEnv: true}); err != nil {
+			return nil, fmt.Errorf("installing dependencies for %s: %w", service.Name, err)
+		}
+		if service.Env != nil {
+			if _, err := envHandler.HandleEnvFiles(service.Dir, target, service.Env.Mode, []string{service.Env.Path}); err != nil {
+				return nil, fmt.Errorf("materializing env for %s: %w", service.Name, err)
+			}
+		}
+		for name, r := range service.Ports {
+			key := instance + ":" + service.Name + ":" + name
+			p, err := leasePort(resources, key, r)
+			if err != nil {
+				return nil, err
+			}
+			running.Ports[name] = p
+		}
+		masked := map[string]string{}
+		if service.Env != nil {
+			for key, value := range service.Env.Set {
+				masked[key] = expand(value, instance, resources)
+			}
+			if err := upsertDotenv(filepath.Join(target, service.Env.Path), masked); err != nil {
+				return nil, fmt.Errorf("masking env for %s: %w", service.Name, err)
+			}
+		}
+		if service.Up != "" {
+			pid, log, err := start(target, service, running.Ports, masked, root, instance)
+			if err != nil {
+				return nil, fmt.Errorf("starting %s: %w", service.Name, err)
+			}
+			running.PID, running.Log = pid, log
+		}
+		running.Dir = target
+		state.Services = append(state.Services, running)
+	}
+	if err := saveResources(root, resources); err != nil {
+		return nil, err
+	}
+	if err := saveState(root, state); err != nil {
+		return nil, err
+	}
+	if err := Register(root); err != nil {
+		return nil, fmt.Errorf("registering workspace: %w", err)
+	}
+	completed = true
+	return state, nil
+}
+
+// Down stops recorded processes and releases the resources for an instance.
+func Down(root, instance string) error {
+	return withLock(root, func() error { return down(root, instance) })
+}
+
+func down(root, instance string) error {
+	state, err := loadState(root, instance)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("instance %q is not up", instance)
+		}
+		return err
+	}
+	resources, err := loadResources(root)
+	if err != nil {
+		return err
+	}
+	for _, service := range state.Services {
+		if service.PID > 0 {
+			_ = stopProcess(service.PID)
+		}
+		for name := range service.Ports {
+			delete(resources, instance+":"+service.Name+":"+name)
+		}
+	}
+	if err := saveResources(root, resources); err != nil {
+		return err
+	}
+	return os.Remove(statePath(root, instance))
+}
+
+func leasePort(resources map[string]int, key string, r Port) (int, error) {
+	if p, ok := resources[key]; ok {
+		return p, nil
+	}
+	used := map[int]bool{}
+	for _, p := range resources {
+		used[p] = true
+	}
+	for p := r.From; p <= r.To; p++ {
+		if !used[p] && portAvailable(p) {
+			resources[key] = p
+			return p, nil
+		}
+	}
+	return 0, fmt.Errorf("no ports available for %s", key)
+}
+func portAvailable(port int) bool {
+	listener, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(port))
+	if err != nil {
+		return false
+	}
+	return listener.Close() == nil
+}
+
+func expand(value, instance string, resources map[string]int) string {
+	value = strings.ReplaceAll(value, "${instance}", strings.ReplaceAll(instance, "/", "_"))
+	for key, port := range resources {
+		parts := strings.Split(key, ":")
+		if len(parts) == 3 && parts[0] == instance {
+			value = strings.ReplaceAll(value, "${port."+parts[2]+"}", strconv.Itoa(port))
+		}
+	}
+	return value
+}
+
+func upsertDotenv(path string, values map[string]string) error {
+	if len(values) == 0 {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	lines := strings.Split(string(data), "\n")
+	seen := map[string]bool{}
+	for i, line := range lines {
+		for key, value := range values {
+			if strings.HasPrefix(line, key+"=") {
+				lines[i] = key + "=" + value
+				seen[key] = true
+			}
+		}
+	}
+	for key, value := range values {
+		if !seen[key] {
+			lines = append(lines, key+"="+value)
+		}
+	}
+	return os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0o600)
+}
+
+func start(dir string, service PlanService, ports map[string]int, masked map[string]string, root, instance string) (int, string, error) {
+	log := filepath.Join(root, ".wtf", "state", "logs", stateID(instance), service.Name+".log")
+	if err := os.MkdirAll(filepath.Dir(log), 0o755); err != nil {
+		return 0, "", err
+	}
+	f, err := os.OpenFile(log, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return 0, "", err
+	}
+	cmd := exec.Command("sh", "-c", service.Up)
+	cmd.Dir = dir
+	isolateProcess(cmd)
+	cmd.Stdout, cmd.Stderr = f, f
+	cmd.Env = os.Environ()
+	for key, value := range masked {
+		cmd.Env = append(cmd.Env, key+"="+value)
+	}
+	names := make([]string, 0, len(ports))
+	for n := range ports {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	for _, n := range names {
+		value := strconv.Itoa(ports[n])
+		cmd.Env = append(cmd.Env, "WTF_PORT_"+strings.ToUpper(strings.ReplaceAll(n, "-", "_"))+"="+value)
+		if n == "http" || len(names) == 1 {
+			cmd.Env = append(cmd.Env, "PORT="+value)
+		}
+	}
+	if err := cmd.Start(); err != nil {
+		_ = f.Close()
+		return 0, "", err
+	}
+	_ = f.Close()
+	pid := cmd.Process.Pid
+	_ = cmd.Process.Release()
+	return pid, log, nil
+}
+func stateID(instance string) string {
+	sum := sha256.Sum256([]byte(instance))
+	return hex.EncodeToString(sum[:8])
+}
+func statePath(root, instance string) string {
+	return filepath.Join(root, ".wtf", "state", "instances", stateID(instance)+".json")
+}
+func resourcePath(root string) string { return filepath.Join(root, ".wtf", "state", "resources.json") }
+func loadState(root, instance string) (*RuntimeState, error) {
+	b, err := os.ReadFile(statePath(root, instance))
+	if err != nil {
+		return nil, err
+	}
+	var s RuntimeState
+	if err := json.Unmarshal(b, &s); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+func saveState(root string, s *RuntimeState) error { return saveJSON(statePath(root, s.Instance), s) }
+func loadResources(root string) (map[string]int, error) {
+	b, err := os.ReadFile(resourcePath(root))
+	if os.IsNotExist(err) {
+		return map[string]int{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var r map[string]int
+	if err := json.Unmarshal(b, &r); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+func saveResources(root string, r map[string]int) error { return saveJSON(resourcePath(root), r) }
+func saveJSON(path string, value any) error {
+	b, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, b, 0o600)
+}

--- a/internal/workspace/status.go
+++ b/internal/workspace/status.go
@@ -1,0 +1,11 @@
+package workspace
+
+// IsRunning reports whether every process declared by an instance is alive.
+func IsRunning(state RuntimeState) bool {
+	for _, service := range state.Services {
+		if service.PID > 0 && !processAlive(service.PID) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary
- add profile manifests, planning, lifecycle commands, resource leases, dotenv masks, and runtime state
- add scoped/global instance listing with liveness status
- document and dogfood the profile workflow

## Validation
- `task all`
- `prek run --all-files`
- manual three-instance Work profile exercise (linked UI/API port pairs)

## Risk / follow-up
- This is an experimental spike. Add dedicated lifecycle integration coverage before production release.
- Port availability still cannot prevent an unrelated external process from binding after WTF releases its availability probe.